### PR TITLE
Update wallet constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 
 .idea
+/local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.5.10"
+    kotlin("jvm") version "1.5.20"
     application
 }
 
@@ -19,7 +19,10 @@ dependencies {
     implementation("com.google.guava:guava:30.0-jre")
 
     // bitcoindevkit
-    implementation("org.bitcoindevkit:bdk:0.0.1-dev")
+    implementation("org.bitcoindevkit:bdk:0.0.1-SNAPSHOT")
+
+    // test dependencies
+    testImplementation("junit:junit:4.13.2")
 }
 
 application {

--- a/app/src/main/kotlin/bdkserverside/jvm/MiniWallet.kt
+++ b/app/src/main/kotlin/bdkserverside/jvm/MiniWallet.kt
@@ -1,20 +1,22 @@
 package bdkserverside.jvm
 
-import org.bitcoindevkit.bdk.WalletResult
+import org.bitcoindevkit.bdk.ElectrumConfig
+import org.bitcoindevkit.bdk.MemoryConfig
+import org.bitcoindevkit.bdk.Wallet
 
 object MiniWallet {
-
-    val name = "testnetwallet"
+    
     val desc =
         "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
     val change =
         "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/1/*)"
 
     fun newAddress(): String {
-        val walletResult = WalletResult(name, desc, change)
-        val wallet = walletResult.ok()
-        val address = wallet!!.getAddress()
-        return address.toString()
+        val bcConfig = ElectrumConfig("ssl://electrum.blockstream.info:60002", null, 5, 30)
+        val dbConfig = MemoryConfig()
+        val wallet = Wallet(desc, change, bcConfig, dbConfig)
+        val address = wallet.getAddress()
+        return address
     }
 }
 

--- a/app/src/test/kotlin/bdkserverside/jvm/AppTest.kt
+++ b/app/src/test/kotlin/bdkserverside/jvm/AppTest.kt
@@ -3,12 +3,14 @@
  */
 package bdkserverside.jvm
 
-import kotlin.test.Test
-import kotlin.test.assertNotNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
 
 class AppTest {
-    @Test fun testAppHasAGreeting() {
-        val classUnderTest = App()
-        assertNotNull(classUnderTest.greeting, "app should have a greeting")
+    
+    @Test
+    fun testWalletHasAddress() {
+        val address = MiniWallet.newAddress()
+        assertNotNull("app should generate an address", address)
     }
 }


### PR DESCRIPTION
Update this project to use updated `bdk-kotlin` wallet constructor. New parameters for blockchain (only electrum available right now) and db (memory or sled).